### PR TITLE
fix: standardize bidding item card size

### DIFF
--- a/app/src/main/java/org/quixalert/br/presentation/pages/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/quixalert/br/presentation/pages/profile/ProfileScreen.kt
@@ -478,12 +478,15 @@ fun BiddingItem(
     Box(
         modifier = Modifier
             .width(200.dp)
+            .height(200.dp)
             .shadow(4.dp, RoundedCornerShape(12.dp))
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
             .clickable { onBiddingClick(bidding) }
     ) {
-        Column {
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
             AsyncImage(
                 model = bidding.image,
                 contentDescription = bidding.title,


### PR DESCRIPTION
- Add fixed height (200.dp) to bidding item container
- Ensure Column fills entire Box space with fillMaxSize
- Maintain existing text overflow handling with ellipsis
- Keep consistent image height at 150.dp

UI/UX: Creates uniform card sizes in bidding list while preserving content constraints